### PR TITLE
Queue info

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker run --name redis -d -p 6379:6379 redis redis-server --requirepass redis
 Start a queue worker.
 
 ```bash
-rq worker --url='redis://:redis@localhost:6379' default download extract transcribe summarise
+rq worker --url='redis://:redis@localhost:6379' default download extract transcribe summarise monitoring
 ```
 
 Start the web server.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker run --name redis -d -p 6379:6379 redis redis-server --requirepass redis
 Start a queue worker.
 
 ```bash
-rq worker --url='redis://:redis@localhost:6379' default download extract transcribe summarise monitoring
+rq worker --with-scheduler --url='redis://:redis@localhost:6379' default download extract transcribe summarise monitoring
 ```
 
 Start the web server.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,11 +1,13 @@
 from fastapi.middleware.cors import CORSMiddleware
+from datetime import datetime, timedelta
 from logging.config import dictConfig
 from fastapi import FastAPI
-import logging
 
 from api.routers import index, urls, lectures, query
 from config.logger import LogConfig, log
+from jobs import get_monitoring_queue
 from config.settings import settings
+import jobs.save_queue_info
 
 
 def main():
@@ -25,5 +27,11 @@ def main():
     app.include_router(urls.router)
     app.include_router(lectures.router)
     app.include_router(query.router)
+
+    # Reset the monitoring queue and restart the workers
+    queue = next(get_monitoring_queue())
+    future = datetime.utcnow() + timedelta(days=1)
+    queue.scheduled_job_registry.remove_jobs(timestamp=future.timestamp())
+    jobs.save_queue_info.job()
 
     return app

--- a/config/logger.py
+++ b/config/logger.py
@@ -30,5 +30,5 @@ class LogConfig(BaseModel):
     }
 
 
-def log():
-    return logging.getLogger(settings.NAME)
+def log(logger_name=settings.NAME):
+    return logging.getLogger(logger_name)

--- a/db/migrations/001_add_queue_info_table.py
+++ b/db/migrations/001_add_queue_info_table.py
@@ -1,0 +1,26 @@
+"""Peewee migrations -- 001_add_queue_info_table.py."""
+
+import peewee as pw
+from peewee_migrate import Migrator
+from decimal import ROUND_HALF_EVEN
+
+from db.models import QueueInfo
+from db.database import db
+
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your migrations here."""
+    db.create_tables([QueueInfo])
+
+
+def rollback(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    db.drop_tables([QueueInfo])

--- a/db/migrations/__init__.py
+++ b/db/migrations/__init__.py
@@ -1,0 +1,23 @@
+from peewee_migrate import Router
+import sys
+import os
+
+from db.database import db
+from config.logger import log
+
+MIGRATIONS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+router = Router(db, migrate_dir=MIGRATIONS_DIR, logger=log())
+
+
+def create_migration():
+    router.create(sys.argv[1])
+
+
+def run_migrations():
+    # Run all unapplied migrations
+    router.run()
+
+
+def rollback():
+    router.rollback()

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -4,3 +4,4 @@ from .lecture import Lecture
 from .query import Query
 from .analysis import Analysis
 from .message import Message
+from .queue_info import QueueInfo

--- a/db/models/queue_info.py
+++ b/db/models/queue_info.py
@@ -12,4 +12,5 @@ class QueueInfo(Base):
     queue_download = peewee.IntegerField(null=False, default=0)
     queue_monitoring = peewee.IntegerField(null=False, default=0)
 
-    workers = peewee.TextField(null=False)
+    workers_idle = peewee.IntegerField(null=False, default=0)
+    workers_busy = peewee.IntegerField(null=False, default=0)

--- a/db/models/queue_info.py
+++ b/db/models/queue_info.py
@@ -1,0 +1,15 @@
+import peewee
+
+from .base import Base
+
+
+class QueueInfo(Base):
+    # Queues
+    queue_default = peewee.IntegerField(null=False, default=0)
+    queue_summarise = peewee.IntegerField(null=False, default=0)
+    queue_transcribe = peewee.IntegerField(null=False, default=0)
+    queue_extract = peewee.IntegerField(null=False, default=0)
+    queue_download = peewee.IntegerField(null=False, default=0)
+    queue_monitoring = peewee.IntegerField(null=False, default=0)
+
+    workers = peewee.TextField(null=False)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - db
       - queue
       - api
-    command: rq worker --url="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}" default download extract transcribe summarise
+    command: rq worker --url="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}" default download extract transcribe summarise monitoring
     deploy:
       replicas: 2
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - db
       - queue
       - api
-    command: rq worker --url="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}" default download extract transcribe summarise monitoring
+    command: rq worker --with-scheduler --url="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}" default download extract transcribe summarise monitoring
     deploy:
       replicas: 2
     volumes:

--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -8,6 +8,7 @@ DOWNLOAD = 'download'
 EXTRACT = 'extract'
 TRANSCRIBE = 'transcribe'
 SUMMARISE = 'summarise'
+MONITORING = 'monitoring'
 
 
 def get_default_queue() -> Queue:
@@ -50,6 +51,15 @@ def get_summarise_queue() -> Queue:
     try:
         conn = get_connection()
         queue = Queue(SUMMARISE, connection=conn)
+        yield queue
+    finally:
+        queue.connection.close()
+
+
+def get_monitoring_queue() -> Queue:
+    try:
+        conn = get_connection()
+        queue = Queue(MONITORING, connection=conn)
         yield queue
     finally:
         queue.connection.close()

--- a/jobs/save_queue_info.py
+++ b/jobs/save_queue_info.py
@@ -1,0 +1,105 @@
+from config.settings import settings
+from redis import Redis
+from rq import Queue
+import subprocess
+import logging
+import os
+
+import jobs.save_queue_info
+from config.settings import settings
+from config.logger import log
+from db.models import QueueInfo
+
+
+def get_queues():
+    cmd = [
+        'rq',
+        'info',
+        '--url',
+        f"redis://:{settings.REDIS_PASSWORD}@{settings.REDIS_HOST}:{settings.REDIS_PORT}",
+        '--only-queues',
+    ]
+
+    env = os.environ.copy()
+    env['PYTHONUNBUFFERED'] = '1'
+
+    log().info(f'executing command [$ {" ".join(cmd)}]')
+
+    process = subprocess.Popen(
+        cmd,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+
+    return process
+
+
+def get_workers():
+    cmd = [
+        'rq',
+        'info',
+        '--url',
+        f"redis://:{settings.REDIS_PASSWORD}@{settings.REDIS_HOST}:{settings.REDIS_PORT}",
+        '--only-workers',
+    ]
+
+    env = os.environ.copy()
+    env['PYTHONUNBUFFERED'] = '1'
+
+    log().info(f'executing command [$ {" ".join(cmd)}]')
+
+    process = subprocess.Popen(
+        cmd,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+
+    return process
+
+
+def job():
+    logger = logging.getLogger('rq.worker')
+
+    info = QueueInfo()
+
+    process = get_queues()
+    for line in iter(process.stdout.readline, b''):
+        line = line.decode()
+        split = line.split(' ')
+        if 'default' in line:
+            info.queue_default = int(split[len(split) - 1].strip())
+
+        if 'summarise' in line:
+            info.queue_summarise = int(split[len(split) - 1].strip())
+
+        if 'transcribe' in line:
+            info.queue_transcribe = int(split[len(split) - 1].strip())
+
+        if 'extract' in line:
+            info.queue_extract = int(split[len(split) - 1].strip())
+
+        if 'download' in line:
+            info.queue_download = int(split[len(split) - 1].strip())
+
+        if 'monitoring' in line:
+            info.queue_monitoring = int(split[len(split) - 1].strip())
+
+    worker_status = ''
+    process = get_workers()
+    for line in iter(process.stdout.readline, b''):
+        line = line.decode()
+        worker_status += line
+
+    info.workers = worker_status
+
+    info.save()
+    log().info('done')
+
+
+# Test run the job
+if __name__ == '__main__':
+    job()

--- a/jobs/save_queue_info.py
+++ b/jobs/save_queue_info.py
@@ -88,16 +88,17 @@ def job():
         if 'monitoring' in line:
             info.queue_monitoring = int(split[len(split) - 1].strip())
 
-    worker_status = ''
     process = get_workers()
     for line in iter(process.stdout.readline, b''):
         line = line.decode()
-        worker_status += line
+        if 'idle' in line:
+            info.workers_idle += 1
 
-    info.workers = worker_status
+        if 'busy' in line:
+            info.workers_busy += 1
 
     info.save()
-    log().info('done')
+    log().info('done.')
 
 
 # Test run the job

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ openai==0.26.5
 openai-whisper==20230124
 packaging==23.0
 peewee==3.15.4
+peewee-migrate==1.6.6
 playwright==1.30.0
 pluggy==1.0.0
 psycopg2==2.9.5

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
     entry_points={
         'console_scripts': [
             'create_db_schema = db.schema:create',
+            'create_migration = db.migrations:create_migration',
+            'migrate_up = db.migrations:run_migrations',
+            'migrate_down = db.migrations:rollback',
         ]
     },
     tests_require=[],


### PR DESCRIPTION
This PR will:
- Add database migration `migrate_up` and `migrate_down` commands
- Add a queue info model stored at `queueinfo` in database, this will hold metrics about the rq queues