### PR TITLE
Run OpenAI requests on a queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker run --name redis -d -p 6379:6379 redis redis-server --requirepass redis
 Start a queue worker.
 
 ```bash
-rq worker --with-scheduler --url='redis://:redis@localhost:6379' default download extract transcribe summarise monitoring approval
+rq worker --with-scheduler --url='redis://:redis@localhost:6379' default download extract transcribe summarise monitoring approval gpt
 ```
 
 Start the web server.

--- a/api/routers/query.py
+++ b/api/routers/query.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from db.crud import (
     get_lecture_by_public_id_and_language,
-    get_query_by_sha,
+    get_most_recent_query_by_sha,
     create_query,
 )
 import tools.text.prompts as prompts
@@ -39,13 +39,15 @@ def new_query(input_data: InputModel) -> OutputModel:
     if lecture is None:
         raise HTTPException(status_code=404)
 
-    query = get_query_by_sha(lecture, Query.make_sha(input_data.query_string))
+    query = get_most_recent_query_by_sha(lecture, Query.make_sha(input_data.query_string))
     if query is None:
         query = create_query(lecture, input_data.query_string)
 
     cached = True
     if query.response is None or input_data.override_cache is True:
         cached = False
+        query = create_query(lecture, input_data.query_string)
+
         if lecture.language == lecture.Language.ENGLISH:
             prompt = prompts.create_query_text_english(query, lecture)
         elif lecture.language == lecture.Language.SWEDISH:

--- a/api/routers/query.py
+++ b/api/routers/query.py
@@ -53,9 +53,19 @@ def new_query(input_data: InputModel) -> OutputModel:
         else:
             raise ValueError(f'language {lecture.language} is not supported')
 
-
         try:
-            response = ai.gpt3(prompt)
+            response = ai.gpt3(
+                prompt,
+                time_to_live=60,
+                max_retries=2,
+                retry_interval=[10, 20]
+            )
+        except ai.GPTException as e:
+            log().error(e)
+            raise HTTPException(
+                status_code=500,
+                detail=str(e)
+            )
         except Exception as e:
             log().error(e)
             raise HTTPException(

--- a/api/routers/query.py
+++ b/api/routers/query.py
@@ -58,7 +58,8 @@ def new_query(input_data: InputModel) -> OutputModel:
                 prompt,
                 time_to_live=60,
                 max_retries=2,
-                retry_interval=[10, 20]
+                retry_interval=[10, 20],
+                query_id=query.id,
             )
         except ai.GPTException as e:
             log().error(e)

--- a/db/crud.py
+++ b/db/crud.py
@@ -35,8 +35,8 @@ def get_unfinished_analysis() -> List[models.Lecture]:
 
 
 # Query
-def get_query_by_sha(lecture: models.Lecture, sha: str) -> models.Query:
-    return models.Query.filter(models.Query.lecture_id == lecture.id).filter(models.Query.query_hash == sha).first()
+def get_most_recent_query_by_sha(lecture: models.Lecture, sha: str) -> models.Query:
+    return models.Query.filter(models.Query.lecture_id == lecture.id).filter(models.Query.query_hash == sha).order_by(models.Query.modified_at.desc()).first()
 
 
 def create_query(lecture: models.Lecture, query_string: str) -> models.Query:

--- a/db/migrations/003_add_token_usage_table.py
+++ b/db/migrations/003_add_token_usage_table.py
@@ -1,0 +1,25 @@
+"""Peewee migrations -- 003_add_token_usage_table.py."""
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+from db.models import TokenUsage
+from db.database import db
+
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your migrations here."""
+    db.create_tables([TokenUsage])
+
+
+def rollback(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    db.drop_tables([TokenUsage])

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -5,3 +5,4 @@ from .query import Query
 from .analysis import Analysis
 from .message import Message
 from .queue_info import QueueInfo
+from .token_usage import TokenUsage

--- a/db/models/token_usage.py
+++ b/db/models/token_usage.py
@@ -1,0 +1,13 @@
+import peewee
+
+from .base import Base
+
+
+class TokenUsage(Base):
+    # not sure how to make this a foreign key field, due to circular imports
+    analysis_id = peewee.IntegerField(null=True, index=True)
+    query_id = peewee.IntegerField(null=True, index=True)
+
+    completion_tokens = peewee.IntegerField(null=False, default=0)
+    prompt_tokens = peewee.IntegerField(null=False, default=0)
+    total_tokens = peewee.IntegerField(null=False, default=0)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,24 @@ services:
     volumes:
       - queue:/data
 
+  queue_worker_gpt:
+    image: kthgpt_main
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    restart: always
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - queue
+      - api
+    command: rq worker --with-scheduler --url="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}" gpt
+    deploy:
+      replicas: 2
+    volumes:
+      - shared:/shared
+
   queue_worker:
     image: kthgpt_main
     build:

--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -22,6 +22,7 @@ EXTRACT = 'extract'
 TRANSCRIBE = 'transcribe'
 SUMMARISE = 'summarise'
 MONITORING = 'monitoring'
+APPROVAL = 'approval'
 
 
 def get_default_queue() -> Queue:
@@ -78,6 +79,15 @@ def get_monitoring_queue() -> Queue:
         queue.connection.close()
 
 
+def get_approval_queue() -> Queue:
+    try:
+        conn = get_connection()
+        queue = Queue(APPROVAL, connection=conn)
+        yield queue
+    finally:
+        queue.connection.close()
+
+
 def get_connection() -> Queue:
     if settings.REDIS_PASSWORD is not None:
         return Redis(
@@ -126,7 +136,7 @@ def schedule_analysis_of_lecture(
 
 def schedule_approval_of_lecture(
     lecture,
-    queue_approval: Queue = get_summarise_queue,
+    queue_approval: Queue = get_approval_queue,
 ):
     log().info(f'Scheduling approval of {lecture.public_id}')
 

--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -23,6 +23,7 @@ TRANSCRIBE = 'transcribe'
 SUMMARISE = 'summarise'
 MONITORING = 'monitoring'
 APPROVAL = 'approval'
+GPT = 'gpt'
 
 
 def get_default_queue() -> Queue:

--- a/jobs/gpt_request.py
+++ b/jobs/gpt_request.py
@@ -1,16 +1,31 @@
-from openai.error import RateLimitError
+from rq import Queue, Retry
 from redis import Redis
-from rq import Queue
 import logging
 
+from db.crud import (
+    get_lecture_by_public_id_and_language,
+    save_message_for_analysis
+)
 from tools.text.openai import completion
 from config.settings import settings
+from db.models import Lecture
 import jobs.gpt_request
 
 
-def job(prompt: str):
+def job(prompt: str, lecture_id: str = None, language: str = None):
     logger = logging.getLogger('rq.worker')
-    response = completion(prompt)
+    try:
+        response = completion(prompt)
+    except Exception as e:
+        logger.error(e)
+        if lecture_id is not None:
+            lecture = get_lecture_by_public_id_and_language(lecture_id, language)
+            if lecture is None:
+                raise ValueError(f'lecture {lecture_id} not found')
+
+            analysis = lecture.get_last_analysis()
+            save_message_for_analysis(analysis, 'OpenAI Error', 'GPT-3 Error from OpenAI, it is likely overloaded. Retrying in a little while...')
+        raise e
     return response
 
 
@@ -21,5 +36,12 @@ if __name__ == '__main__':
         port=settings.REDIS_PORT,
         password=settings.REDIS_PASSWORD,
     ))
-    j = queue.enqueue(jobs.gpt_request.job, 'say hello')
+    j = queue.enqueue(
+        jobs.gpt_request.job,
+        'say hello',
+        'ev_wkULk2sk',
+        Lecture.Language.SWEDISH,
+        ttl=15,
+        retry=Retry(max=2, interval=[5, 5]),
+    )
     print(j.id)

--- a/jobs/gpt_request.py
+++ b/jobs/gpt_request.py
@@ -1,0 +1,25 @@
+from openai.error import RateLimitError
+from redis import Redis
+from rq import Queue
+import logging
+
+from tools.text.openai import completion
+from config.settings import settings
+import jobs.gpt_request
+
+
+def job(prompt: str):
+    logger = logging.getLogger('rq.worker')
+    response = completion(prompt)
+    return response
+
+
+# Test run the job
+if __name__ == '__main__':
+    queue = Queue('gpt', connection=Redis(
+        host=settings.REDIS_HOST,
+        port=settings.REDIS_PORT,
+        password=settings.REDIS_PASSWORD,
+    ))
+    j = queue.enqueue(jobs.gpt_request.job, 'say hello')
+    print(j.id)

--- a/jobs/summarise_transcript.py
+++ b/jobs/summarise_transcript.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     ))
     queue.enqueue(
         jobs.summarise_transcript.job,
-        '0_8fs7zau6',
+        'ev_wkULk2sk',
         Lecture.Language.SWEDISH,
         job_timeout=TIMEOUT
     )

--- a/tools/text/ai.py
+++ b/tools/text/ai.py
@@ -1,14 +1,25 @@
+from datetime import datetime, timedelta
 from openai.error import RateLimitError
+from rq import Queue, Retry
+from redis import Redis
+from rq.job import Job
 import tiktoken
-import logging
-import openai
-import time
+import asyncio
 
-from db.crud import save_message_for_analysis
-from db.models.lecture import Lecture
 from config.settings import settings
+from config.logger import log
+import jobs.gpt_request
+
 
 MODEL = 'text-davinci-003'
+
+GPT_QUEUE_NAME = 'gpt'
+
+POLLING_INTERVAL_SECONDS = 0.1
+
+
+class GPTException(Exception):
+    pass
 
 
 class RetryLimitException(Exception):
@@ -19,61 +30,106 @@ class TokenLimitExceededException(Exception):
     pass
 
 
+class JobResponseErrorException(Exception):
+    pass
+
+
+class JobTimeoutException(Exception):
+    pass
+
+
+def get_gpt_queue() -> Queue:
+    try:
+        conn = get_connection()
+        queue = Queue(GPT_QUEUE_NAME, connection=conn)
+        yield queue
+    finally:
+        queue.connection.close()
+
+
+def get_connection() -> Queue:
+    if settings.REDIS_PASSWORD is not None:
+        return Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            password=settings.REDIS_PASSWORD,
+        )
+
+    return Redis(
+        host=settings.REDIS_HOST,
+        port=settings.REDIS_PORT,
+    )
+
+
 def get_max_tokens(prompt: str) -> int:
     encoder = tiktoken.encoding_for_model(MODEL)
     return 4000 - len(encoder.encode(prompt))
 
 
-def gpt3(prompt: str, retry_limit=10) -> str:
-    if retry_limit <= 0:
-        raise RetryLimitException('reached retry limit')
+def gpt3(
+    prompt: str,
+    time_to_live: int = 60,
+    max_retries: int = 3,
+    retry_interval: list = [10, 30, 60],
+    queue_approval: Queue = get_gpt_queue,
+) -> str:
+    q = next(queue_approval())
 
-    tokens = get_max_tokens(prompt)
-    if tokens < 0:
-        raise TokenLimitExceededException(f'too many tokens ({tokens})')
-
-    openai.api_key = settings.OPENAI_API_KEY
-    completion = openai.Completion.create(
-        engine=MODEL,
-        prompt=prompt,
-        max_tokens=get_max_tokens(prompt),
+    job = q.enqueue(
+        jobs.gpt_request.job,
+        prompt,
+        ttl=time_to_live,
+        retry=Retry(max=max_retries, interval=retry_interval)
     )
 
-    return completion['choices'][0]['text'].strip()
-
-
-def gpt3_safe(prompt: str, lecture: Lecture, retry_limit=50) -> str:
-    logger = logging.getLogger('rq.worker')
-
-    if retry_limit <= 0:
-        raise RetryLimitException('reached retry limit')
-
-    tokens = get_max_tokens(prompt)
-    if tokens < 0:
-        raise TokenLimitExceededException(f'too many tokens ({tokens})')
-
-    openai.api_key = settings.OPENAI_API_KEY
     try:
-        completion = openai.Completion.create(
-            engine=MODEL,
-            prompt=prompt,
-            max_tokens=get_max_tokens(prompt),
-        )
-    except RateLimitError:
-        logger.warning('hit rate limit, waiting 10s')
-        lecture.refresh()
-        analysis = lecture.get_last_analysis()
-        save_message_for_analysis(analysis, 'Creating summary', 'OpenAI is overloaded, waiting a little while.')
-        time.sleep(10)
-        return gpt3_safe(prompt, lecture, retry_limit=retry_limit-1)
-    except Exception as e:
-        logger.error('got an unexpected error, waiting 60s')
-        logger.error(e)
+        response = asyncio.run(wait_for_response(
+            job.id,
+            get_connection(),
+            time_to_live,
+        ))
+        return response
+    except JobResponseErrorException as e:
+        log().error(e)
+        raise GPTException('GPT-3 Error. OpenAI failed, it is likely overloaded.')
+    except JobTimeoutException as e:
+        log().error(e)
+        raise GPTException('GPT-3 Error. OpenAI took too long, it is likely overloaded.')
+    except RateLimitError as e:
+        log().error(e)
+        raise GPTException('GPT-3 Rate limit. kthGPT is overloaded.')
 
-        lecture.refresh()
-        analysis = lecture.get_last_analysis()
-        save_message_for_analysis(analysis, 'Creating summary', 'Got an error from OpenAI, it is probably overloaded, waiting a little while.')
-        time.sleep(15)
-        return gpt3_safe(prompt, lecture, retry_limit=retry_limit-1)
 
-    return completion['choices'][0]['text'].strip()
+async def wait_for_response(job_id: str, connection: Queue, trigger_timout_after: int) -> str:
+    timeout_after = datetime.utcnow() + timedelta(seconds=trigger_timout_after)
+
+    job = Job.fetch(job_id, connection=connection)
+
+    while True:
+        job.refresh()
+
+        now = datetime.utcnow()
+        if now > timeout_after:
+            raise JobTimeoutException(f'reached job timeout limit of {trigger_timout_after}')
+
+        status = job.get_status()
+        print(status)
+        if status == 'finished':
+            return job.result
+
+        error_statuses = [
+            'stopped',
+            'canceled',
+            'failed',
+        ]
+        if status in error_statuses:
+            # Some messy error handling here since the error
+            # info is sent back as a string from rq
+
+            rate_limit = (RateLimitError()).__class__.__name__
+            if rate_limit in str(job.exc_info):
+                raise RateLimitError()
+
+            raise JobResponseErrorException(f'job failed with error {status}')
+
+        await asyncio.sleep(POLLING_INTERVAL_SECONDS)

--- a/tools/text/ai.py
+++ b/tools/text/ai.py
@@ -113,7 +113,6 @@ async def wait_for_response(job_id: str, connection: Queue, trigger_timout_after
             raise JobTimeoutException(f'reached job timeout limit of {trigger_timout_after}')
 
         status = job.get_status()
-        print(status)
         if status == 'finished':
             return job.result
 

--- a/tools/text/ai.py
+++ b/tools/text/ai.py
@@ -74,16 +74,16 @@ def gpt3(
     max_retries: int = 3,
     retry_interval: list = [10, 30, 60],
     queue_approval: Queue = get_gpt_queue,
-    lecture_public_id: Optional[str] = None,
-    lecture_language: Optional[str] = None,
+    analysis_id: Optional[int] = None,
+    query_id: Optional[int] = None,
 ) -> str:
     q = next(queue_approval())
 
     job = q.enqueue(
         jobs.gpt_request.job,
         prompt,
-        lecture_public_id,
-        lecture_language,
+        analysis_id,
+        query_id,
         ttl=time_to_live,
         retry=Retry(max=max_retries, interval=retry_interval)
     )

--- a/tools/text/openai.py
+++ b/tools/text/openai.py
@@ -1,7 +1,9 @@
+from typing import Tuple
 import tiktoken
 import openai
 
 from config.settings import settings
+from db.models import TokenUsage
 
 
 MODEL = 'text-davinci-003'
@@ -20,7 +22,7 @@ def get_max_tokens(prompt: str) -> int:
     return 4000 - len(encoder.encode(prompt))
 
 
-def completion(prompt: str) -> str:
+def completion(prompt: str) -> Tuple[str, TokenUsage]:
     tokens = get_max_tokens(prompt)
     if tokens < 0:
         raise TokenLimitExceededException(f'to many tokens ({tokens})')
@@ -35,4 +37,9 @@ def completion(prompt: str) -> str:
     except Exception as e:
         raise UnexpectedOpenAIException(e)
 
-    return completion['choices'][0]['text'].strip()
+    usage = TokenUsage(
+        completion_tokens=completion['usage']['completion_tokens'],
+        prompt_tokens=completion['usage']['prompt_tokens'],
+        total_tokens=completion['usage']['total_tokens'],
+    )
+    return completion['choices'][0]['text'].strip(), usage

--- a/tools/text/openai.py
+++ b/tools/text/openai.py
@@ -1,0 +1,38 @@
+import tiktoken
+import openai
+
+from config.settings import settings
+
+
+MODEL = 'text-davinci-003'
+
+
+class TokenLimitExceededException(Exception):
+    pass
+
+
+class UnexpectedOpenAIException(Exception):
+    pass
+
+
+def get_max_tokens(prompt: str) -> int:
+    encoder = tiktoken.encoding_for_model(MODEL)
+    return 4000 - len(encoder.encode(prompt))
+
+
+def completion(prompt: str) -> str:
+    tokens = get_max_tokens(prompt)
+    if tokens < 0:
+        raise TokenLimitExceededException(f'to many tokens ({tokens})')
+
+    openai.api_key = settings.OPENAI_API_KEY
+    try:
+        completion = openai.Completion.create(
+            engine=MODEL,
+            prompt=prompt,
+            max_tokens=get_max_tokens(prompt),
+        )
+    except Exception as e:
+        raise UnexpectedOpenAIException(e)
+
+    return completion['choices'][0]['text'].strip()

--- a/tools/text/summary.py
+++ b/tools/text/summary.py
@@ -80,7 +80,25 @@ class Summary:
             prompt = prompts.create_text_to_summarise_chunk_swedish(self, chunk, include_summary)
         else:
             raise ValueError(f'unsupported language {lecture.language}')
-        response = ai.gpt3_safe(prompt, lecture)
+
+        response = ai.gpt3(
+            prompt,
+            time_to_live=60 * 60 * 10,  # 5 hrs
+            max_retries=10,
+            retry_interval=[
+                10,
+                30,
+                60,
+                2 * 60,
+                2 * 60,
+                10 * 60,
+                30 * 60,
+                2 * 60 * 60,
+                30 * 60,
+                30 * 60,
+            ]
+        )
+
         self.summaries[chunk.period] = response.replace('\n', ' ')
 
     def current_summary(self):
@@ -97,7 +115,24 @@ class Summary:
             prompt = prompts.create_text_to_summarise_summary_swedish(self)
         else:
             raise ValueError(f'unsupported language {self.lecture.language}')
-        response = ai.gpt3_safe(prompt, self.lecture)
+
+        response = ai.gpt3(
+            prompt,
+            time_to_live=60 * 60 * 10,  # 5 hrs
+            max_retries=10,
+            retry_interval=[
+                10,
+                30,
+                60,
+                2 * 60,
+                2 * 60,
+                10 * 60,
+                30 * 60,
+                2 * 60 * 60,
+                30 * 60,
+                30 * 60,
+            ]
+        )
 
         return response
 

--- a/tools/text/summary.py
+++ b/tools/text/summary.py
@@ -81,6 +81,9 @@ class Summary:
         else:
             raise ValueError(f'unsupported language {lecture.language}')
 
+        self.lecture.refresh()
+        analysis = self.lecture.get_last_analysis()
+
         response = ai.gpt3(
             prompt,
             time_to_live=60 * 60 * 10,  # 5 hrs
@@ -97,8 +100,7 @@ class Summary:
                 30 * 60,
                 30 * 60,
             ],
-            lecture_public_id=self.lecture.public_id,
-            lecture_language=self.lecture.language,
+            analysis_id=analysis.id,
         )
 
         self.summaries[chunk.period] = response.replace('\n', ' ')
@@ -118,6 +120,9 @@ class Summary:
         else:
             raise ValueError(f'unsupported language {self.lecture.language}')
 
+        self.lecture.refresh()
+        analysis = self.lecture.get_last_analysis()
+
         response = ai.gpt3(
             prompt,
             time_to_live=60 * 60 * 10,  # 5 hrs
@@ -134,8 +139,7 @@ class Summary:
                 30 * 60,
                 30 * 60,
             ],
-            lecture_public_id=self.lecture.public_id,
-            lecture_language=self.lecture.language,
+            analysis_id=analysis.id,
         )
 
         return response

--- a/tools/text/summary.py
+++ b/tools/text/summary.py
@@ -96,7 +96,9 @@ class Summary:
                 2 * 60 * 60,
                 30 * 60,
                 30 * 60,
-            ]
+            ],
+            lecture_public_id=self.lecture.public_id,
+            lecture_language=self.lecture.language,
         )
 
         self.summaries[chunk.period] = response.replace('\n', ' ')
@@ -131,7 +133,9 @@ class Summary:
                 2 * 60 * 60,
                 30 * 60,
                 30 * 60,
-            ]
+            ],
+            lecture_public_id=self.lecture.public_id,
+            lecture_language=self.lecture.language,
         )
 
         return response

--- a/tools/web/camera.py
+++ b/tools/web/camera.py
@@ -5,7 +5,9 @@ import asyncio
 from db.models import Lecture
 
 
-YOUTUBE_COOKIE_BTN_SELECTOR = '[aria-label="Accept the use of cookies and other data for the purposes described"]'
+# The two different buttons that has been seen
+YOUTUBE_COOKIE_BTN_SELECTOR_1 = '[aria-label="Accept the use of cookies and other data for the purposes described"]'
+YOUTUBE_COOKIE_BTN_SELECTOR_2 = '[aria-label="Accept all"]'
 
 
 def save_photo(url: str, lecture: Lecture) -> str:
@@ -25,10 +27,11 @@ async def save_photo_async_wrapper(url: str, lecture: Lecture) -> str:
             pass
 
         if lecture.source == lecture.Source.YOUTUBE:
-            element = await page.query_selector(YOUTUBE_COOKIE_BTN_SELECTOR)
-            if element is not None:
-                await element.click()
-                await asyncio.sleep(2)
+            for btn in [YOUTUBE_COOKIE_BTN_SELECTOR_1, YOUTUBE_COOKIE_BTN_SELECTOR_2]:
+                element = await page.query_selector(btn)
+                if element is not None:
+                    await element.click()
+                    await asyncio.sleep(2)
 
         await asyncio.sleep(1)
         await page.screenshot(path=lecture.preview_filename())

--- a/tools/web/camera.py
+++ b/tools/web/camera.py
@@ -27,6 +27,7 @@ async def save_photo_async_wrapper(url: str, lecture: Lecture) -> str:
             pass
 
         if lecture.source == lecture.Source.YOUTUBE:
+            await asyncio.sleep(5)
             for btn in [YOUTUBE_COOKIE_BTN_SELECTOR_1, YOUTUBE_COOKIE_BTN_SELECTOR_2]:
                 element = await page.query_selector(btn)
                 if element is not None:

--- a/tools/web/camera.py
+++ b/tools/web/camera.py
@@ -26,8 +26,9 @@ async def save_photo_async_wrapper(url: str, lecture: Lecture) -> str:
 
         if lecture.source == lecture.Source.YOUTUBE:
             element = await page.query_selector(YOUTUBE_COOKIE_BTN_SELECTOR)
-            await element.click()
-            await asyncio.sleep(2)
+            if element is not None:
+                await element.click()
+                await asyncio.sleep(2)
 
         await asyncio.sleep(1)
         await page.screenshot(path=lecture.preview_filename())

--- a/web-ui/src/components/analyser/analyser.tsx
+++ b/web-ui/src/components/analyser/analyser.tsx
@@ -71,11 +71,11 @@ const prettyTimeElapsedString = (date: Date) => {
     return 'over 1h ago';
   }
 
-  if (seconds < 5) {
-    return 'Just now';
-  }
-
   if (minutes === 0) {
+    if (seconds < 5) {
+      return 'Just now';
+    }
+
     return `${seconds}s ago`;
   }
 


### PR DESCRIPTION
This PR will:
- Fix approval queue running on the wrong queue name
- Improve stability and resilience of GPT-3 completion requests by running them on a queue and utilise `rq` retry mechanics
- Write token usage of GPT-3 completion requests to a new `tokenusage` table