### PR TITLE
Build package images in GitHub

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  pull_request: # (this is only here temporarily, can't be tested easily with act)
   push:
     tags:
       - v*.*

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -1,0 +1,45 @@
+name: Build
+on:
+  push:
+    tags:
+      - v*.*
+      - v*.*.*
+
+env:
+  REGISTRY: ghcr.io
+
+# docker build -f web-ui/Dockerfile web-ui -t kthgpt_frontend --no-cache
+# docker build -f api/Dockerfile .
+jobs:
+  build_api_image:
+    name: API Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: actions/checkout@v3
+        with:
+          images: ${{ env.REGISTRY }}/kthgpt-api
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            kthgpt/api
+            ${{ env.REGISTRY }}/kthgpt/api
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -32,9 +32,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: actions/checkout@v3
+        uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/kthgpt-api
+          images: |
+            kthgpt/api
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY }}/kthgpt/api
+            ${{ env.REGISTRY }}/nattvara/kthgpt/api
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -1,6 +1,5 @@
 name: Build
 on:
-  pull_request: # (this is only here temporarily, can't be tested easily with act)
   push:
     tags:
       - v*.*

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -120,3 +120,40 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build_worker_gpu_image:
+    name: Worker Image (GPU Accelerated)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/nattvara/kthgpt/worker-gpu-accelerated
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: worker/Dockerfile.gpu_accelerated
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -83,3 +83,40 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build_worker_image:
+    name: Worker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/nattvara/kthgpt/worker
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: worker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -9,8 +9,6 @@ on:
 env:
   REGISTRY: ghcr.io
 
-# docker build -f web-ui/Dockerfile web-ui -t kthgpt_frontend --no-cache
-# docker build -f api/Dockerfile .
 jobs:
   build_api_image:
     name: API Image
@@ -45,6 +43,43 @@ jobs:
         with:
           context: .
           file: api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_web_ui_image:
+    name: Web UI Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/nattvara/kthgpt/web-ui
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: web-ui
+          file: web-ui/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,7 @@ version: "3.8"
 
 services:
   init_db:
-    image: kthgpt_main
-    build:
-      context: .
-      dockerfile: api/Dockerfile
+    image: ghcr.io/nattvara/kthgpt/api:latest
     env_file:
       - .env
     depends_on:
@@ -15,10 +12,7 @@ services:
     command: create_db_schema
 
   api:
-    image: kthgpt_main
-    build:
-      context: .
-      dockerfile: api/Dockerfile
+    image: ghcr.io/nattvara/kthgpt/api:latest
     restart: always
     env_file:
       - .env
@@ -59,10 +53,7 @@ services:
       - discovery.type=single-node
 
   queue_worker_gpt:
-    image: kthgpt_main
-    build:
-      context: .
-      dockerfile: api/Dockerfile
+    image: ghcr.io/nattvara/kthgpt/worker:latest
     restart: always
     env_file:
       - .env
@@ -77,10 +68,7 @@ services:
       - shared:/shared
 
   queue_worker:
-    image: kthgpt_main
-    build:
-      context: .
-      dockerfile: api/Dockerfile
+    image: ghcr.io/nattvara/kthgpt/worker:latest
     restart: always
     env_file:
       - .env
@@ -95,10 +83,7 @@ services:
       - shared:/shared
 
   frontend:
-    image: kthgpt_frontend
-    build:
-      context: web-ui
-      dockerfile: ./Dockerfile
+    image: ghcr.io/nattvara/kthgpt/web-ui:latest
     restart: always
     env_file:
       - .env


### PR DESCRIPTION
This PR will:
- Add workflow that builds docker images on a tag push to the repository
- The repository now maintains the following images
  - `kthgpt/api`, the api image
  - `kthgpt/web-ui`, the frontend image
  - `kthgpt/worker`, a standard worker image
  - `kthgpt/worker-gpu-accelerated`, a worker image with drivers and libraries to execute ML models on a NVIDIA GPU
- Update docker compose example to use pre-built images