### PR TITLE
Fix workflows triggering on bad formats

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     tags:
-      - v*.*
+      # Tags must be on the format vx.x.x, eg. v1.2.0
       - v*.*.*
 
 env:


### PR DESCRIPTION
This PR will:
- Change Build workflow to only trigger on tag versions with the following format `vx.x.x` (caused issues with docker tag action)