### PR TITLE
Improve event emissions

### DIFF
--- a/web-ui/src/components/analyser/analyser.tsx
+++ b/web-ui/src/components/analyser/analyser.tsx
@@ -19,7 +19,13 @@ import { history } from 'umi';
 import Preview from '../preview';
 import LectureProgress from './lecture-progress';
 import CourseSelector from './course-selector';
-import { CATEGORY_QUESTIONS, EVENT_GOTO_LECTURE, emitEvent } from '@/matomo';
+import {
+  emitEvent,
+  CATEGORY_QUESTIONS,
+  EVENT_GOTO_LECTURE,
+  CATEGORY_ANALYSE,
+  EVENT_ERROR_RESPONSE,
+} from '@/matomo';
 
 const { Paragraph, Link } = Typography;
 
@@ -76,6 +82,7 @@ export default function Analyser(props: AnalyserProps) {
         if (err.response.status === 404) {
           setNotFound(true);
         }
+        emitEvent(CATEGORY_ANALYSE, EVENT_ERROR_RESPONSE, 'fetchLecture');
       },
     }
   );
@@ -98,6 +105,11 @@ export default function Analyser(props: AnalyserProps) {
           message: 'Failed to get lectures',
           description: err.response.data.detail,
         });
+        emitEvent(
+          CATEGORY_ANALYSE,
+          EVENT_ERROR_RESPONSE,
+          'fetchUnfinishedLectures'
+        );
       },
     }
   );
@@ -137,6 +149,7 @@ export default function Analyser(props: AnalyserProps) {
           message: 'Failed restart analysis',
           description: err.response.data.detail,
         });
+        emitEvent(CATEGORY_ANALYSE, EVENT_ERROR_RESPONSE, 'postUrl');
       },
     }
   );

--- a/web-ui/src/components/analyser/course-selector.tsx
+++ b/web-ui/src/components/analyser/course-selector.tsx
@@ -9,6 +9,11 @@ import {
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import apiClient, { ServerErrorResponse, ServerResponse } from '@/http';
+import {
+  emitEvent,
+  CATEGORY_COURSE_SELECTOR,
+  EVENT_ERROR_RESPONSE,
+} from '@/matomo';
 
 const { Search } = Input;
 const { Title, Paragraph } = Typography;
@@ -42,6 +47,7 @@ function CourseSearch(props: CourseSearchProps) {
       },
       onError: (err: ServerErrorResponse) => {
         console.log(err);
+        emitEvent(CATEGORY_COURSE_SELECTOR, EVENT_ERROR_RESPONSE, 'doSearch');
       },
     }
   );
@@ -126,6 +132,7 @@ function NonAddedCourse(props: NonAddedCourseProps) {
         message: 'Course was not added',
         description: (err as ServerErrorResponse).response.data.detail,
       });
+      emitEvent(CATEGORY_COURSE_SELECTOR, EVENT_ERROR_RESPONSE, 'addCourse');
     } finally {
       await setLoading(false);
     }
@@ -183,6 +190,7 @@ function AddedCourse(props: AddedCourseProps) {
         message: 'Course was not removed',
         description: (err as ServerErrorResponse).response.data.detail,
       });
+      emitEvent(CATEGORY_COURSE_SELECTOR, EVENT_ERROR_RESPONSE, 'removeCourse');
     } finally {
       await setLoading(false);
     }

--- a/web-ui/src/components/questions/questions.tsx
+++ b/web-ui/src/components/questions/questions.tsx
@@ -214,7 +214,7 @@ export default function Questions(props: QuestionsProps) {
 
     makeQuery();
 
-    emitEvent(CATEGORY_QUESTIONS, EVENT_ASKED_QUESTION, ACTION_NONE);
+    emitEvent(CATEGORY_QUESTIONS, EVENT_ASKED_QUESTION, queryString);
   };
 
   const askQuestionWithoutCache = async () => {
@@ -223,7 +223,7 @@ export default function Questions(props: QuestionsProps) {
     await setOverrideCache(true);
     askQuestion();
 
-    emitEvent(CATEGORY_QUESTIONS, EVENT_ASKED_QUESTION_NO_CACHE, ACTION_NONE);
+    emitEvent(CATEGORY_QUESTIONS, EVENT_ASKED_QUESTION_NO_CACHE, queryString);
   };
 
   if (notFound === true) {

--- a/web-ui/src/components/questions/questions.tsx
+++ b/web-ui/src/components/questions/questions.tsx
@@ -21,6 +21,7 @@ import {
   ACTION_NONE,
   CATEGORY_QUESTIONS,
   EVENT_RECEIVED_QUESTION_ANSWER,
+  EVENT_ERROR_RESPONSE,
 } from '@/matomo';
 import CourseSelector from '../analyser/course-selector';
 
@@ -128,6 +129,7 @@ export default function Questions(props: QuestionsProps) {
         if (err.response.status === 404) {
           setNotFound(true);
         }
+        emitEvent(CATEGORY_QUESTIONS, EVENT_ERROR_RESPONSE, 'fetchLecture');
       },
     }
   );
@@ -178,6 +180,7 @@ export default function Questions(props: QuestionsProps) {
         } else {
           setError('Something went wrong when communicating with OpenAI.');
         }
+        emitEvent(CATEGORY_QUESTIONS, EVENT_ERROR_RESPONSE, 'makeQuery');
       },
     }
   );
@@ -199,6 +202,11 @@ export default function Questions(props: QuestionsProps) {
         },
         onError: (err: ServerErrorResponse) => {
           console.error(err);
+          emitEvent(
+            CATEGORY_QUESTIONS,
+            EVENT_ERROR_RESPONSE,
+            'fetchTranscript'
+          );
         },
       }
     );

--- a/web-ui/src/components/questions/questions.tsx
+++ b/web-ui/src/components/questions/questions.tsx
@@ -20,6 +20,7 @@ import {
   emitEvent,
   ACTION_NONE,
   CATEGORY_QUESTIONS,
+  EVENT_RECEIVED_QUESTION_ANSWER,
 } from '@/matomo';
 import CourseSelector from '../analyser/course-selector';
 
@@ -154,6 +155,11 @@ export default function Questions(props: QuestionsProps) {
           headers: res.headers,
           data: res.data,
         };
+        emitEvent(
+          CATEGORY_QUESTIONS,
+          EVENT_RECEIVED_QUESTION_ANSWER,
+          ACTION_NONE
+        );
         setError('');
         setResponse(result.data.response);
         setWasCached(result.data.cached);

--- a/web-ui/src/components/selector/course-browser.tsx
+++ b/web-ui/src/components/selector/course-browser.tsx
@@ -16,6 +16,7 @@ import {
   EVENT_GOTO_COURSE,
   emitEvent,
   EVENT_GOTO_LECTURE,
+  EVENT_ERROR_RESPONSE,
 } from '@/matomo';
 
 const { Search } = Input;
@@ -70,6 +71,11 @@ export default function CourseBrowser(props: CourseBrowserProps) {
       },
       onError: (err: ServerErrorResponse) => {
         console.log(err);
+        emitEvent(
+          CATEGORY_COURSE_BROWSER,
+          EVENT_ERROR_RESPONSE,
+          'doCourseSearch'
+        );
       },
     }
   );
@@ -89,6 +95,11 @@ export default function CourseBrowser(props: CourseBrowserProps) {
         },
         onError: (err: ServerErrorResponse) => {
           console.log(err);
+          emitEvent(
+            CATEGORY_COURSE_BROWSER,
+            EVENT_ERROR_RESPONSE,
+            'doLectureSearch'
+          );
         },
       }
     );

--- a/web-ui/src/components/selector/lecture-adder.tsx
+++ b/web-ui/src/components/selector/lecture-adder.tsx
@@ -23,7 +23,13 @@ import kthLogo from '@/assets/kth.svg';
 import youtubeLogo from '@/assets/youtube.svg';
 import svFlag from '@/assets/flag-sv.svg';
 import enFlag from '@/assets/flag-en.svg';
-import { CATEGORY_ADDER, emitEvent, EVENT_SUBMIT_URL } from '@/matomo';
+import {
+  emitEvent,
+  CATEGORY_URL,
+  EVENT_SUBMIT_URL_KTH,
+  EVENT_SUBMIT_URL_YOUTUBE,
+  EVENT_SUBMIT_URL_UNKNOWN,
+} from '@/matomo';
 
 const { Title, Link, Paragraph } = Typography;
 const { Meta } = Card;
@@ -269,7 +275,13 @@ export default function LectureAdder() {
 
   const submit = async () => {
     await postUrl();
-    emitEvent(CATEGORY_ADDER, EVENT_SUBMIT_URL, source);
+    if (source === SOURCE_YOUTUBE) {
+      emitEvent(CATEGORY_URL, EVENT_SUBMIT_URL_YOUTUBE, url);
+    } else if (source === SOURCE_KTH) {
+      emitEvent(CATEGORY_URL, EVENT_SUBMIT_URL_KTH, url);
+    } else {
+      emitEvent(CATEGORY_URL, EVENT_SUBMIT_URL_UNKNOWN, url);
+    }
   };
 
   return (

--- a/web-ui/src/components/selector/lecture-adder.tsx
+++ b/web-ui/src/components/selector/lecture-adder.tsx
@@ -29,6 +29,8 @@ import {
   EVENT_SUBMIT_URL_KTH,
   EVENT_SUBMIT_URL_YOUTUBE,
   EVENT_SUBMIT_URL_UNKNOWN,
+  CATEGORY_LECTURE_ADDER,
+  EVENT_ERROR_RESPONSE,
 } from '@/matomo';
 
 const { Title, Link, Paragraph } = Typography;
@@ -269,6 +271,7 @@ export default function LectureAdder() {
       },
       onError: (err: ServerErrorResponse) => {
         setError(err.response.data.detail);
+        emitEvent(CATEGORY_LECTURE_ADDER, EVENT_ERROR_RESPONSE, 'postUrl');
       },
     }
   );

--- a/web-ui/src/components/selector/selector.tsx
+++ b/web-ui/src/components/selector/selector.tsx
@@ -5,6 +5,7 @@ import { FileSearchOutlined, VideoCameraAddOutlined } from '@ant-design/icons';
 import CourseBrowser from './course-browser';
 import apiClient from '@/http';
 import LectureAdder from './lecture-adder';
+import { emitEvent, CATEGORY_SELECTOR, EVENT_ERROR_RESPONSE } from '@/matomo';
 
 const { Title } = Typography;
 
@@ -27,6 +28,7 @@ export default function Selector() {
       await setStats(response.data);
     } catch (err: unknown) {
       console.log(err);
+      emitEvent(CATEGORY_SELECTOR, EVENT_ERROR_RESPONSE, 'fetchStats');
     }
   };
 

--- a/web-ui/src/components/tables/denied-table.tsx
+++ b/web-ui/src/components/tables/denied-table.tsx
@@ -10,6 +10,11 @@ import svFlag from '@/assets/flag-sv.svg';
 import enFlag from '@/assets/flag-en.svg';
 import kthLogo from '@/assets/kth.svg';
 import youtubeLogo from '@/assets/youtube.svg';
+import {
+  emitEvent,
+  CATEGORY_DENIED_TABLE,
+  EVENT_ERROR_RESPONSE,
+} from '@/matomo';
 
 const { Link } = Typography;
 
@@ -125,6 +130,7 @@ export default function DeniedTable() {
           message: 'Failed to get lectures',
           description: err.response.data.detail,
         });
+        emitEvent(CATEGORY_DENIED_TABLE, EVENT_ERROR_RESPONSE, 'fetchLectures');
       },
     }
   );

--- a/web-ui/src/components/tables/failures-table.tsx
+++ b/web-ui/src/components/tables/failures-table.tsx
@@ -10,6 +10,11 @@ import svFlag from '@/assets/flag-sv.svg';
 import enFlag from '@/assets/flag-en.svg';
 import kthLogo from '@/assets/kth.svg';
 import youtubeLogo from '@/assets/youtube.svg';
+import {
+  emitEvent,
+  CATEGORY_FAILURE_TABLE,
+  EVENT_ERROR_RESPONSE,
+} from '@/matomo';
 
 const { Link } = Typography;
 
@@ -132,6 +137,11 @@ export default function FailuresTable() {
           message: 'Failed to get lectures',
           description: err.response.data.detail,
         });
+        emitEvent(
+          CATEGORY_FAILURE_TABLE,
+          EVENT_ERROR_RESPONSE,
+          'fetchLectures'
+        );
       },
     }
   );

--- a/web-ui/src/components/tables/queue-table.tsx
+++ b/web-ui/src/components/tables/queue-table.tsx
@@ -10,6 +10,11 @@ import svFlag from '@/assets/flag-sv.svg';
 import enFlag from '@/assets/flag-en.svg';
 import kthLogo from '@/assets/kth.svg';
 import youtubeLogo from '@/assets/youtube.svg';
+import {
+  emitEvent,
+  CATEGORY_QUEUE_TABLE,
+  EVENT_ERROR_RESPONSE,
+} from '@/matomo';
 
 const UPDATE_INTERVAL = 10000;
 
@@ -143,6 +148,7 @@ export default function QueueTable() {
           message: 'Failed to get lectures',
           description: err.response.data.detail,
         });
+        emitEvent(CATEGORY_QUEUE_TABLE, EVENT_ERROR_RESPONSE, 'fetchLectures');
       },
     }
   );

--- a/web-ui/src/matomo/index.tsx
+++ b/web-ui/src/matomo/index.tsx
@@ -12,6 +12,8 @@ export const CATEGORY_COURSE_BROWSER = 'course_browser';
 
 export const EVENT_ASKED_QUESTION = 'asked_question';
 
+export const EVENT_RECEIVED_QUESTION_ANSWER = 'received_question_response';
+
 export const EVENT_ASKED_QUESTION_NO_CACHE =
   'asked_question_with_cache_override';
 

--- a/web-ui/src/matomo/index.tsx
+++ b/web-ui/src/matomo/index.tsx
@@ -8,7 +8,17 @@ export const CATEGORY_PREVIEW = 'preview';
 
 export const CATEGORY_URL = 'submit_url';
 
+export const CATEGORY_LECTURE_ADDER = 'lecture_adder';
+
 export const CATEGORY_COURSE_BROWSER = 'course_browser';
+
+export const CATEGORY_COURSE_SELECTOR = 'course_selector';
+
+export const CATEGORY_QUEUE_TABLE = 'queue_table';
+
+export const CATEGORY_FAILURE_TABLE = 'failure_table';
+
+export const CATEGORY_DENIED_TABLE = 'denied_table';
 
 export const EVENT_ASKED_QUESTION = 'asked_question';
 
@@ -30,6 +40,8 @@ export const EVENT_GOTO_LECTURE = 'goto_lecture';
 export const EVENT_GOTO_CONTENT = 'goto_content';
 
 export const EVENT_GOTO_COURSE = 'goto_course';
+
+export const EVENT_ERROR_RESPONSE = 'error_response';
 
 export const ACTION_NONE = '_';
 

--- a/web-ui/src/matomo/index.tsx
+++ b/web-ui/src/matomo/index.tsx
@@ -6,7 +6,7 @@ export const CATEGORY_QUESTIONS = 'questions';
 
 export const CATEGORY_PREVIEW = 'preview';
 
-export const CATEGORY_ADDER = 'adder';
+export const CATEGORY_URL = 'submit_url';
 
 export const CATEGORY_COURSE_BROWSER = 'course_browser';
 
@@ -17,7 +17,11 @@ export const EVENT_ASKED_QUESTION_NO_CACHE =
 
 export const EVENT_FEELING_LUCKY = 'feeling_lucky';
 
-export const EVENT_SUBMIT_URL = 'submit_url';
+export const EVENT_SUBMIT_URL_KTH = 'url_kth';
+
+export const EVENT_SUBMIT_URL_YOUTUBE = 'url_youtube';
+
+export const EVENT_SUBMIT_URL_UNKNOWN = 'url_unknown';
 
 export const EVENT_GOTO_LECTURE = 'goto_lecture';
 


### PR DESCRIPTION
The purpose of this PR is to improve event tracking:
- To understand which requests cause errors for users
- To understand which submitted URLs fail

This PR will:
- Add event emissions to matomo in each http `onError` handler
- Add event emissions for URL submissions to understand which URLs are handled and which aren't