### PR TITLE
Cache image search gpt requests

### DIFF
--- a/api/routers/assignments.py
+++ b/api/routers/assignments.py
@@ -30,6 +30,7 @@ class ImageOutputModel(BaseModel):
     can_ask_question: bool
     description_en: Optional[str]
     description_sv: Optional[str]
+    parse_image_upload_complete: bool
     parse_image_content_ok: Optional[bool]
     create_description_en_ok: Optional[bool]
     create_description_sv_ok: Optional[bool]

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -3,9 +3,9 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from api.routers.lectures import LectureSummaryOutputModel
+from db.models import ImageQuestion, ImageQuestionHit
 import index.courses as courses_index
 import tools.text.prompts as prompts
-from db.models import ImageQuestion
 from db.models import Lecture
 from config.logger import log
 from db import get_db
@@ -13,6 +13,7 @@ import index.lecture
 import tools.text.ai
 from db.crud import (
     get_lecture_by_public_id_and_language,
+    get_image_question_hit_by_public_id,
     get_image_upload_by_public_id,
     get_lecture_by_id,
 )
@@ -43,9 +44,16 @@ class InputModelImageQuestion(BaseModel):
     query: str
 
 
+class HitOutputModel(BaseModel):
+    id: str
+    answer: Optional[str] = None
+    relevance: Optional[str] = None
+    lecture: Optional[LectureSummaryOutputModel]
+
+
 class ImageQuestionOutputModel(BaseModel):
     id: str
-    hits: List[LectureSummaryOutputModel]
+    hits: List[HitOutputModel]
 
 
 class LectureAnswerOutputModel(BaseModel):
@@ -203,20 +211,29 @@ def create_image_question(
             break
 
         lecture = get_lecture_by_id(id)
-        lectures.append(lecture.to_dict())
+        lectures.append(lecture)
+
+    hits = []
+    for lecture in lectures:
+        hit = ImageQuestionHit(
+            public_id=ImageQuestionHit.make_public_id(),
+            image_question_id=question.id,
+            lecture_id=lecture.id,
+        )
+        hit.save()
+        hits.append(hit.to_dict())
 
     return {
         'id': question.public_id,
-        'hits': lectures,
+        'hits': hits,
     }
 
 
-@router.get('/search/image/{image_public_id}/questions/{question_public_id}/{lecture_public_id}/{lecture_language}/answer', dependencies=[Depends(get_db)])  # noqa: E501
+@router.get('/search/image/{image_public_id}/questions/{question_public_id}/hits/{question_hit_public_id}/answer', dependencies=[Depends(get_db)])  # noqa: E501
 def get_answer_to_question_hit(
     image_public_id: str,
     question_public_id: str,
-    lecture_public_id: str,
-    lecture_language: str,
+    question_hit_public_id: str,
 ) -> LectureAnswerOutputModel:
     upload = get_image_upload_by_public_id(image_public_id)
 
@@ -231,37 +248,23 @@ def get_answer_to_question_hit(
     if question is None:
         raise HTTPException(status_code=404)
 
-    lecture = get_lecture_by_public_id_and_language(
-        lecture_public_id,
-        lecture_language,
-    )
-    if lecture is None:
+    hit = get_image_question_hit_by_public_id(question_hit_public_id)
+    if hit is None:
         raise HTTPException(status_code=404)
 
-    prompt = prompts.create_prompt_to_answer_question_about_hit(
-        lecture,
-        upload,
-        question,
-    )
-    response = tools.text.ai.gpt3(
-        prompt,
-        time_to_live=60,
-        max_retries=2,
-        retry_interval=[10, 20],
-        upload_id=upload.id,
-    )
+    hit.create_answer(tools.text.ai, prompts)
+    hit.save()
 
     return {
-        'answer': response,
+        'answer': hit.answer,
     }
 
 
-@router.get('/search/image/{image_public_id}/questions/{question_public_id}/{lecture_public_id}/{lecture_language}/relevance', dependencies=[Depends(get_db)])  # noqa: E501
+@router.get('/search/image/{image_public_id}/questions/{question_public_id}/hits/{question_hit_public_id}/relevance', dependencies=[Depends(get_db)])  # noqa: E501
 def get_relevance_of_question_hit(
     image_public_id: str,
     question_public_id: str,
-    lecture_public_id: str,
-    lecture_language: str,
+    question_hit_public_id: str,
 ) -> LectureRelevanceOutputModel:
     upload = get_image_upload_by_public_id(image_public_id)
 
@@ -276,26 +279,13 @@ def get_relevance_of_question_hit(
     if question is None:
         raise HTTPException(status_code=404)
 
-    lecture = get_lecture_by_public_id_and_language(
-        lecture_public_id,
-        lecture_language,
-    )
-    if lecture is None:
+    hit = get_image_question_hit_by_public_id(question_hit_public_id)
+    if hit is None:
         raise HTTPException(status_code=404)
 
-    prompt = prompts.create_prompt_to_explain_hit_relevance(
-        lecture,
-        upload,
-        question,
-    )
-    response = tools.text.ai.gpt3(
-        prompt,
-        time_to_live=60,
-        max_retries=2,
-        retry_interval=[10, 20],
-        upload_id=upload.id,
-    )
+    hit.create_relevance(tools.text.ai, prompts)
+    hit.save()
 
     return {
-        'relevance': response,
+        'relevance': hit.relevance,
     }

--- a/db/crud.py
+++ b/db/crud.py
@@ -287,6 +287,12 @@ def get_image_questions_by_image_upload_id(id: int):
     return ImageQuestion.filter(ImageQuestion.image_upload_id == id)
 
 
+# ImageQuestionHit
+def get_image_question_hits_by_image_question_id(id: int):
+    from db.models import ImageQuestionHit
+    return ImageQuestionHit.filter(ImageQuestionHit.image_question_id == id)
+
+
 # Mathpix requests
 def get_mathpix_requests_by_image_upload_id(id: int):
     from db.models import MathpixRequest

--- a/db/crud.py
+++ b/db/crud.py
@@ -271,6 +271,11 @@ def get_image_upload_by_public_id(id: str):
     return ImageUpload.filter(ImageUpload.public_id == id).first()
 
 
+def get_image_upload_by_id(id: str):
+    from db.models import ImageUpload
+    return ImageUpload.filter(ImageUpload.id == id).first()
+
+
 def get_image_upload_by_image_sha(sha: str):
     from db.models import ImageUpload
     return ImageUpload.filter(ImageUpload.image_sha == sha).first()
@@ -280,6 +285,11 @@ def get_image_upload_by_image_sha(sha: str):
 def get_image_question_by_public_id(id: str):
     from db.models import ImageQuestion
     return ImageQuestion.filter(ImageQuestion.public_id == id).first()
+
+
+def get_image_question_by_id(id: int):
+    from db.models import ImageQuestion
+    return ImageQuestion.filter(ImageQuestion.id == id).first()
 
 
 def get_image_questions_by_image_upload_id(id: int):

--- a/db/crud.py
+++ b/db/crud.py
@@ -297,10 +297,34 @@ def get_image_questions_by_image_upload_id(id: int):
     return ImageQuestion.filter(ImageQuestion.image_upload_id == id)
 
 
+def get_most_recent_image_question_by_sha(upload, sha: str):
+    from db.models import ImageQuestion
+    return ImageQuestion.filter(
+        ImageQuestion.image_upload_id == upload.id
+    ).filter(
+        ImageQuestion.query_hash == sha
+    ).order_by(
+        ImageQuestion.modified_at.desc()
+    ).first()
+
+
 # ImageQuestionHit
 def get_image_question_hit_by_public_id(id: str):
     from db.models import ImageQuestionHit
     return ImageQuestionHit.filter(ImageQuestionHit.public_id == id).first()
+
+
+def get_most_recent_question_hit_by_lecture_and_question(lecture, image_question):
+    from db.models import ImageQuestionHit
+    return ImageQuestionHit.filter(
+        ImageQuestionHit.lecture_id == lecture.id
+    ).filter(
+        ImageQuestionHit.image_question_id == image_question.id
+    ).filter(
+        ImageQuestionHit.cache_is_valid == True  # noqa: E712
+    ).order_by(
+        ImageQuestionHit.modified_at.desc()
+    ).first()
 
 
 def get_image_question_hits_by_image_question_id(id: int):

--- a/db/crud.py
+++ b/db/crud.py
@@ -298,6 +298,11 @@ def get_image_questions_by_image_upload_id(id: int):
 
 
 # ImageQuestionHit
+def get_image_question_hit_by_public_id(id: str):
+    from db.models import ImageQuestionHit
+    return ImageQuestionHit.filter(ImageQuestionHit.public_id == id).first()
+
+
 def get_image_question_hits_by_image_question_id(id: int):
     from db.models import ImageQuestionHit
     return ImageQuestionHit.filter(ImageQuestionHit.image_question_id == id)

--- a/db/migrations/018_add_image_question_hit_table.py
+++ b/db/migrations/018_add_image_question_hit_table.py
@@ -1,0 +1,16 @@
+"""Peewee migrations -- 018_add_image_question_hit_table.py."""
+import peewee as pw
+from peewee_migrate import Migrator
+
+from db.models import ImageQuestionHit
+from db.database import db
+
+
+def migrate(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your migrations here."""
+    db.create_tables([ImageQuestionHit])
+
+
+def rollback(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    db.drop_tables([ImageQuestionHit])

--- a/db/migrations/019_add_query_hash_column_to_image_question_table.py
+++ b/db/migrations/019_add_query_hash_column_to_image_question_table.py
@@ -1,0 +1,20 @@
+"""Peewee migrations -- 019_add_query_hash_column_to_image_question_table.py."""
+import peewee as pw
+from peewee_migrate import Migrator
+
+from db.models import ImageQuestion
+
+
+def migrate(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your migrations here."""
+    field = pw.CharField(index=True, null=True)
+    migrator.add_fields(
+        ImageQuestion,
+        query_hash=field,
+    )
+    migrator.run()
+
+
+def rollback(migrator: Migrator, database: pw.Database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    migrator.remove_fields(ImageQuestion, 'query_hash', cascade=True)

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -13,5 +13,5 @@ from .course import (
     CourseLectureRelation,
 )
 from .image_upload import ImageUpload
-from .image_question import ImageQuestion
+from .image_question import ImageQuestion, ImageQuestionHit
 from .mathpix_request import MathpixRequest

--- a/db/models/image_question.py
+++ b/db/models/image_question.py
@@ -1,3 +1,4 @@
+import hashlib
 import peewee
 import uuid
 
@@ -20,10 +21,15 @@ class ImageQuestion(Base):
     public_id = peewee.CharField(null=False, unique=True)
     image_upload_id = peewee.ForeignKeyField(ImageUpload, null=False, backref='imageupload', on_delete='cascade')
     query_string = peewee.TextField(null=False)
+    query_hash = peewee.CharField(index=True, null=True)
 
     @staticmethod
     def make_public_id() -> str:
         return str(uuid.uuid4())
+
+    @staticmethod
+    def make_sha(string: str) -> str:
+        return hashlib.sha256(string.encode()).hexdigest()
 
     def hits(self) -> list:
         return list(get_image_question_hits_by_image_question_id(self.id))
@@ -124,7 +130,7 @@ class ImageQuestionHit(Base):
         lecture = get_lecture_by_id(self.lecture_id)
         lecture_dict = None
         if lecture is not None:
-            lecture_dict = lecture.to_summary_dict()
+            lecture_dict = lecture.to_dict()
 
         return {
             'id': self.public_id,

--- a/db/models/image_question.py
+++ b/db/models/image_question.py
@@ -2,13 +2,33 @@ import peewee
 import uuid
 
 from .image_upload import ImageUpload
+from .lecture import Lecture
 from .base import Base
+from db.crud import (
+    get_image_question_hits_by_image_question_id,
+)
 
 
 class ImageQuestion(Base):
     public_id = peewee.CharField(null=False, unique=True)
     image_upload_id = peewee.ForeignKeyField(ImageUpload, null=False, backref='imageupload', on_delete='cascade')
     query_string = peewee.TextField(null=False)
+
+    @staticmethod
+    def make_public_id() -> str:
+        return str(uuid.uuid4())
+
+    def hits(self) -> list:
+        return list(get_image_question_hits_by_image_question_id(self.id))
+
+
+class ImageQuestionHit(Base):
+    public_id = peewee.CharField(null=False, unique=True)
+    image_question_id = peewee.ForeignKeyField(ImageQuestion, null=False, backref='imagequestion', on_delete='cascade')
+    lecture_id = peewee.ForeignKeyField(Lecture, null=True, backref='lecture', on_delete='set null')
+    response = peewee.TextField(null=True)
+    cache_is_valid = peewee.BooleanField(null=False, default=True)
+    count = peewee.IntegerField(null=False, default=0)
 
     @staticmethod
     def make_public_id() -> str:

--- a/db/models/image_question.py
+++ b/db/models/image_question.py
@@ -6,7 +6,14 @@ from .lecture import Lecture
 from .base import Base
 from db.crud import (
     get_image_question_hits_by_image_question_id,
+    get_image_question_by_id,
+    get_image_upload_by_id,
+    get_lecture_by_id,
 )
+
+
+class ImageQuestionHitException(Exception):
+    pass
 
 
 class ImageQuestion(Base):
@@ -26,10 +33,77 @@ class ImageQuestionHit(Base):
     public_id = peewee.CharField(null=False, unique=True)
     image_question_id = peewee.ForeignKeyField(ImageQuestion, null=False, backref='imagequestion', on_delete='cascade')
     lecture_id = peewee.ForeignKeyField(Lecture, null=True, backref='lecture', on_delete='set null')
-    response = peewee.TextField(null=True)
+    answer = peewee.TextField(null=True)
+    relevance = peewee.TextField(null=True)
     cache_is_valid = peewee.BooleanField(null=False, default=True)
     count = peewee.IntegerField(null=False, default=0)
 
     @staticmethod
     def make_public_id() -> str:
         return str(uuid.uuid4())
+
+    def create_answer(self, ai, prompts):
+        if self.answer is not None and self.cache_is_valid:
+            return
+
+        lecture = get_lecture_by_id(self.lecture_id)
+        if lecture is None:
+            raise ImageQuestionHitException(f'Lecture with id {self.lecture_id} not found')
+
+        question = get_image_question_by_id(self.image_question_id)
+        if question is None:
+            raise ImageQuestionHitException(f'ImageQuestion with id {self.image_question_id} not found')
+
+        upload = get_image_upload_by_id(question.image_upload_id)
+        if upload is None:
+            raise ImageQuestionHitException(f'ImageUpload with id {question.image_upload_id} not found')
+
+        prompt = prompts.create_prompt_to_answer_question_about_hit(
+            lecture,
+            upload,
+            question,
+        )
+
+        response = ai.gpt3(
+            prompt,
+            time_to_live=60,
+            max_retries=2,
+            retry_interval=[10, 20],
+            upload_id=upload.id,
+        )
+
+        self.answer = response
+        self.cache_is_valid = True
+
+    def create_relevance(self, ai, prompts):
+        if self.relevance is not None and self.cache_is_valid:
+            return
+
+        lecture = get_lecture_by_id(self.lecture_id)
+        if lecture is None:
+            raise ImageQuestionHitException(f'Lecture with id {self.lecture_id} not found')
+
+        question = get_image_question_by_id(self.image_question_id)
+        if question is None:
+            raise ImageQuestionHitException(f'ImageQuestion with id {self.image_question_id} not found')
+
+        upload = get_image_upload_by_id(question.image_upload_id)
+        if upload is None:
+            raise ImageQuestionHitException(f'ImageUpload with id {question.image_upload_id} not found')
+
+        prompt = prompts.create_prompt_to_explain_hit_relevance(
+            lecture,
+            upload,
+            question,
+        )
+
+        response = ai.gpt3(
+            prompt,
+            time_to_live=60,
+            max_retries=2,
+            retry_interval=[10, 20],
+            upload_id=upload.id,
+        )
+
+        self.relevance = response
+        self.cache_is_valid = True

--- a/db/models/image_question.py
+++ b/db/models/image_question.py
@@ -42,6 +42,16 @@ class ImageQuestionHit(Base):
     def make_public_id() -> str:
         return str(uuid.uuid4())
 
+    def refresh(self):
+        update = ImageQuestionHit.get(self.id)
+        self.public_id = update.public_id
+        self.image_question_id = update.image_question_id
+        self.lecture_id = update.lecture_id
+        self.answer = update.answer
+        self.relevance = update.relevance
+        self.cache_is_valid = update.cache_is_valid
+        self.count = update.count
+
     def create_answer(self, ai, prompts):
         if self.answer is not None and self.cache_is_valid:
             return
@@ -72,6 +82,7 @@ class ImageQuestionHit(Base):
             upload_id=upload.id,
         )
 
+        self.refresh()
         self.answer = response
         self.cache_is_valid = True
 
@@ -105,5 +116,19 @@ class ImageQuestionHit(Base):
             upload_id=upload.id,
         )
 
+        self.refresh()
         self.relevance = response
         self.cache_is_valid = True
+
+    def to_dict(self) -> dict:
+        lecture = get_lecture_by_id(self.lecture_id)
+        lecture_dict = None
+        if lecture is not None:
+            lecture_dict = lecture.to_summary_dict()
+
+        return {
+            'id': self.public_id,
+            'lecture': lecture_dict,
+            'answer': self.answer,
+            'relevance': self.relevance,
+        }

--- a/db/models/image_upload.py
+++ b/db/models/image_upload.py
@@ -159,6 +159,7 @@ class ImageUpload(Base):
             'can_ask_question': self.can_ask_question(),
             'description_en': self.description_en,
             'description_sv': self.description_sv,
+            'parse_image_upload_complete': self.parse_image_upload_complete(),
             'parse_image_content_ok': self.parse_image_content_ok,
             'create_description_en_ok': self.create_description_en_ok,
             'create_description_sv_ok': self.create_description_sv_ok,

--- a/db/schema.py
+++ b/db/schema.py
@@ -12,6 +12,7 @@ from .models import (
     TokenUsage,
     ImageUpload,
     ImageQuestion,
+    ImageQuestionHit,
     MathpixRequest,
 )
 
@@ -29,6 +30,7 @@ all_models = [
     TokenUsage,
     ImageUpload,
     ImageQuestion,
+    ImageQuestionHit,
     MathpixRequest,
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ import shutil
 import json
 import os
 
+from db.models import ImageUpload, ImageQuestion
 from config.settings import settings
-from db.models import ImageUpload
 from db.schema import all_models
 import api
 
@@ -171,6 +171,18 @@ def image_upload(img_file):
             img.write(src.read())
 
     return image
+
+
+@pytest.fixture
+def image_question(image_upload):
+    question = ImageQuestion(
+        public_id=ImageQuestion.make_public_id(),
+        image_upload_id=image_upload.id,
+        query_string='help me',
+    )
+    question.save()
+
+    return question
 
 
 @pytest.fixture

--- a/tests/feature/api/test_search.py
+++ b/tests/feature/api/test_search.py
@@ -379,8 +379,8 @@ def test_image_question_aggregates_the_top_hits(mocker, api_client, image_upload
 
     assert index_mock.call_count == swedish_queries + english_queries
     assert len(response.json()['hits']) == 2
-    for lecture in response.json()['hits']:
-        assert lecture['public_id'] in ['id-1', 'id-2']
+    for hit in response.json()['hits']:
+        assert hit['lecture']['public_id'] in ['id-1', 'id-2']
 
 
 def test_answer_to_question_hit_can_be_retrieved(
@@ -408,7 +408,7 @@ def test_answer_to_question_hit_can_be_retrieved(
     hit = response.json()['hits'][0]
 
     response = api_client.get(
-        f'/search/image/{image_upload.public_id}/questions/{question_id}/{hit["public_id"]}/{hit["language"]}/answer',
+        f'/search/image/{image_upload.public_id}/questions/{question_id}/hits/{hit["id"]}/answer',
     )
 
     assert response.json()['answer'] == 'you can find the answer here'
@@ -439,7 +439,7 @@ def test_relevance_of_hit_can_be_retrieved(
     hit = response.json()['hits'][0]
 
     response = api_client.get(
-        f'/search/image/{image_upload.public_id}/questions/{question_id}/{hit["public_id"]}/{hit["language"]}/relevance',
+        f'/search/image/{image_upload.public_id}/questions/{question_id}/hits/{hit["id"]}/relevance',
     )
 
     assert response.json()['relevance'] == 'this is relevant because'

--- a/tests/unit/db/models/test_image_question.py
+++ b/tests/unit/db/models/test_image_question.py
@@ -1,6 +1,8 @@
 
 from db.crud import get_image_question_by_public_id
 from db.models import ImageQuestion, ImageQuestionHit
+import tools.text.prompts as prompts
+import tools.text.ai
 
 
 def test_image_question_can_be_saved(image_upload):
@@ -25,9 +27,154 @@ def test_image_question_hit_can_be_saved(image_question, analysed_lecture):
     )
     hit.save()
 
-    assert hit.response is None
+    assert hit.answer is None
+    assert hit.relevance is None
     assert hit.cache_is_valid is True
 
     # Test accessor from ImageQuestion
     assert len(image_question.hits()) == 1
     assert image_question.hits()[0].id == hit.id
+
+
+def test_image_question_hit_can_compute_answer(mocker, image_question, analysed_lecture):
+    answer = 'some ai wizardry'
+    mocker.patch('tools.text.ai.gpt3', return_value=answer)
+
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    hit.create_answer(tools.text.ai, prompts)
+    hit.save()
+
+    assert hit.answer == answer
+
+
+def test_image_question_hit_answer_is_cached(mocker, image_question, analysed_lecture):
+    answer = 'some ai wizardry'
+    gpt3_mock = mocker.patch('tools.text.ai.gpt3', return_value=answer)
+
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    def func():
+        hit.create_answer(tools.text.ai, prompts)
+        hit.save()
+
+    # call the function a few times
+    func()
+    func()
+    func()
+
+    assert hit.answer == answer
+    assert gpt3_mock.call_count == 1
+
+
+def test_image_question_hit_answer_can_be_expired(mocker, image_question, analysed_lecture):
+    answer = 'some ai wizardry'
+    gpt3_mock = mocker.patch('tools.text.ai.gpt3', return_value=answer)
+
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    def func():
+        hit.create_answer(tools.text.ai, prompts)
+        hit.save()
+
+    func()
+    func()
+    func()
+
+    assert hit.answer == answer
+    assert gpt3_mock.call_count == 1
+
+    hit.cache_is_valid = False
+    hit.save()
+    func()
+    func()
+
+    assert hit.answer == answer
+    assert gpt3_mock.call_count == 2
+
+
+def test_image_question_hit_can_compute_relevance(mocker, image_question, analysed_lecture):
+    relevance = 'the ai did wizardry'
+    mocker.patch('tools.text.ai.gpt3', return_value=relevance)
+
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    hit.create_relevance(tools.text.ai, prompts)
+    hit.save()
+
+    assert hit.relevance == relevance
+
+
+def test_image_question_hit_relevance_is_cached(mocker, image_question, analysed_lecture):
+    relevance = 'the ai did wizardry'
+    gpt3_mock = mocker.patch('tools.text.ai.gpt3', return_value=relevance)
+
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    def func():
+        hit.create_relevance(tools.text.ai, prompts)
+        hit.save()
+
+    # call the function a few times
+    func()
+    func()
+    func()
+
+    assert hit.relevance == relevance
+    assert gpt3_mock.call_count == 1
+
+
+def test_image_question_hit_relevance_can_be_expired(mocker, image_question, analysed_lecture):
+    relevance = 'the ai did wizardry'
+    gpt3_mock = mocker.patch('tools.text.ai.gpt3', return_value=relevance)
+
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    def func():
+        hit.create_relevance(tools.text.ai, prompts)
+        hit.save()
+
+    func()
+    func()
+    func()
+
+    assert hit.relevance == relevance
+    assert gpt3_mock.call_count == 1
+
+    hit.cache_is_valid = False
+    hit.save()
+    func()
+    func()
+
+    assert hit.relevance == relevance
+    assert gpt3_mock.call_count == 2

--- a/tests/unit/db/models/test_image_question.py
+++ b/tests/unit/db/models/test_image_question.py
@@ -1,0 +1,33 @@
+
+from db.crud import get_image_question_by_public_id
+from db.models import ImageQuestion, ImageQuestionHit
+
+
+def test_image_question_can_be_saved(image_upload):
+    public_id = ImageQuestion.make_public_id()
+
+    question = ImageQuestion(
+        public_id=public_id,
+        image_upload_id=image_upload.id,
+        query_string='help me',
+    )
+    question.save()
+
+    saved = get_image_question_by_public_id(public_id)
+    assert question.id == saved.id
+
+
+def test_image_question_hit_can_be_saved(image_question, analysed_lecture):
+    hit = ImageQuestionHit(
+        public_id=ImageQuestionHit.make_public_id(),
+        image_question_id=image_question.id,
+        lecture_id=analysed_lecture.id,
+    )
+    hit.save()
+
+    assert hit.response is None
+    assert hit.cache_is_valid is True
+
+    # Test accessor from ImageQuestion
+    assert len(image_question.hits()) == 1
+    assert image_question.hits()[0].id == hit.id

--- a/web-ui/src/components/image/image-question/image-question.tsx
+++ b/web-ui/src/components/image/image-question/image-question.tsx
@@ -88,7 +88,7 @@ export default function ImageQuestion(props: ImageQuestionProps) {
       <Row>
         <QuestionInput
           language={'en'}
-          placeholder={'Enter a question about this image...'}
+          placeholder={'Enter a question about this assignment...'}
           disabled={!image.can_ask_question}
           isAsking={false}
           examples={[

--- a/web-ui/src/components/searching/search-by-image/search-by-image.less
+++ b/web-ui/src/components/searching/search-by-image/search-by-image.less
@@ -8,3 +8,7 @@
   text-align: center;
   padding-top: 30px;
 }
+
+.result {
+  margin-bottom: 40px;
+}

--- a/web-ui/src/components/searching/search-by-image/search-by-image.tsx
+++ b/web-ui/src/components/searching/search-by-image/search-by-image.tsx
@@ -155,41 +155,39 @@ export default function SearchByImage(props: SearchByImageProps) {
       </Row>
 
       {!isSearching && (
-        <Row>
-          <Row className={styles.result}>
-            <Space direction="vertical" size="large">
-              {hits.map((hit, index) => {
-                if (index + 1 > limit) {
-                  return <div key={hit.id}></div>;
-                }
+        <Row className={styles.result}>
+          {hits.map((hit, index) => {
+            if (index + 1 > limit) {
+              return <div key={hit.id}></div>;
+            }
 
-                return (
-                  <Row key={hit.id}>
-                    <Col span={2} className={styles.row_number}>
-                      {index + 1}
-                    </Col>
-                    <Col span={22}>
-                      <Row>
-                        <LecturePreviewCompact
-                          lecture={hit.lecture}
-                          onClick={() => goToLecture(hit.lecture)}
-                          onMetaClick={() => goToLecture(hit.lecture, true)}
-                          onCtrlClick={() => goToLecture(hit.lecture, true)}
-                        />
-                      </Row>
-                      <Row>
-                        <ImageQuestionHit
-                          hit={hit}
-                          imageId={image.id}
-                          searchQuestionId={searchQuestionId}
-                        />
-                      </Row>
-                    </Col>
-                  </Row>
-                );
-              })}
-            </Space>
-          </Row>
+            return (
+              <Row key={hit.id}>
+                <Col span={2} className={styles.row_number}>
+                  {index + 1}
+                </Col>
+                <Col span={22}>
+                  <Space direction="vertical" size="middle">
+                    <Row>
+                      <LecturePreviewCompact
+                        lecture={hit.lecture}
+                        onClick={() => goToLecture(hit.lecture)}
+                        onMetaClick={() => goToLecture(hit.lecture, true)}
+                        onCtrlClick={() => goToLecture(hit.lecture, true)}
+                      />
+                    </Row>
+                    <Row>
+                      <ImageQuestionHit
+                        hit={hit}
+                        imageId={image.id}
+                        searchQuestionId={searchQuestionId}
+                      />
+                    </Row>
+                  </Space>
+                </Col>
+              </Row>
+            );
+          })}
         </Row>
       )}
 

--- a/web-ui/src/components/searching/search-by-image/search-by-image.tsx
+++ b/web-ui/src/components/searching/search-by-image/search-by-image.tsx
@@ -113,7 +113,7 @@ export default function SearchByImage(props: SearchByImageProps) {
 
   useEffect(() => {
     search();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [image.parse_image_upload_complete]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/web-ui/src/components/searching/search-by-image/search-by-image.tsx
+++ b/web-ui/src/components/searching/search-by-image/search-by-image.tsx
@@ -4,7 +4,7 @@ import { Hit, Image, Question } from '@/types/search';
 import { useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import apiClient, { ServerErrorResponse, ServerResponse } from '@/http';
-import { ReloadOutlined } from '@ant-design/icons';
+import { LoadingOutlined, ReloadOutlined } from '@ant-design/icons';
 import { SearchResultLoading } from '@/components/searching/search-result-loading/search-result-loading';
 import { history } from 'umi';
 import { LecturePreviewCompact } from '@/components/lecture/lecture-preview/lecture-preview';
@@ -49,6 +49,7 @@ export default function SearchByImage(props: SearchByImageProps) {
 
   const { isLoading: isSearching, mutate: doSearch } = useMutation(
     async () => {
+      setNotReady(false);
       return await apiClient.post(
         `/search/image/${image.id}/questions`,
         {
@@ -65,7 +66,6 @@ export default function SearchByImage(props: SearchByImageProps) {
           data: res.data,
         };
         setError('');
-        setNotReady(false);
         setHits(result.data.hits);
         setSearchQuestionId(result.data.id);
       },
@@ -142,9 +142,16 @@ export default function SearchByImage(props: SearchByImageProps) {
       )}
 
       <Row className={styles.full_width}>
-        {(isSearching || notReady) && (
-          <SearchResultLoading size={6} min={3} max={6} />
+        {notReady && (
+          <Result
+            icon={<LoadingOutlined />}
+            title="Once kthGPT has understood the assignment, it will try to find the relevant lectures and display them here"
+          />
         )}
+      </Row>
+
+      <Row className={styles.full_width}>
+        {isSearching && <SearchResultLoading size={6} min={3} max={6} />}
       </Row>
 
       {!isSearching && (
@@ -186,23 +193,27 @@ export default function SearchByImage(props: SearchByImageProps) {
         </Row>
       )}
 
-      <Row justify="center" className={styles.full_width}>
-        <Col>
-          <Button
-            onClick={() => increaseLimit()}
-            type="primary"
-            key="btn"
-            size="large"
-          >
-            Load 3 more hits
-          </Button>
-        </Col>
-      </Row>
-      <Row justify="center" className={styles.full_width}>
-        <Paragraph>
-          Showing {limit} / {hits.length} hits
-        </Paragraph>
-      </Row>
+      {!isSearching && !notReady && (
+        <>
+          <Row justify="center" className={styles.full_width}>
+            <Col>
+              <Button
+                onClick={() => increaseLimit()}
+                type="primary"
+                key="btn"
+                size="large"
+              >
+                Load 3 more hits
+              </Button>
+            </Col>
+          </Row>
+          <Row justify="center" className={styles.full_width}>
+            <Paragraph>
+              Showing {limit} / {hits.length} hits
+            </Paragraph>
+          </Row>
+        </>
+      )}
     </>
   );
 }

--- a/web-ui/src/pages/assignments/index.tsx
+++ b/web-ui/src/pages/assignments/index.tsx
@@ -21,8 +21,8 @@ import ImageProgress from '@/components/image/image-progress/image-progress';
 import { history } from 'umi';
 import ImageDescription from '@/components/image/image-description/image-description';
 import ImageQuestion from '@/components/image/image-question/image-question';
-import ImageLectureMatches from '@/components/searching/search-by-image/search-by-image';
 import ImageParseFailure from '@/components/image/image-parse-failure/image-parse-failure';
+import SearchByImage from '@/components/searching/search-by-image/search-by-image';
 
 const { Title, Paragraph } = Typography;
 
@@ -197,7 +197,7 @@ export default function AssignmentsIndexPage() {
                 how to solve this assignment.
               </Paragraph>
               <Row className={styles.full_width}>
-                <ImageLectureMatches image={image} />
+                <SearchByImage image={image} />
               </Row>
             </Row>
           </Col>

--- a/web-ui/src/pages/assignments/index.tsx
+++ b/web-ui/src/pages/assignments/index.tsx
@@ -193,8 +193,10 @@ export default function AssignmentsIndexPage() {
                 🧑‍🏫 Where can I learn how to solve this assignment?
               </Title>
               <Paragraph>
-                kthGPT is trying to find which lectures and where you can learn
-                how to solve this assignment.
+                kthGPT is trying to find
+                <strong> which lectures are relevant</strong> for this
+                assignment, and <strong>where in them</strong> you can find the
+                information you need to solve the assignment.
               </Paragraph>
               <Row className={styles.full_width}>
                 <SearchByImage image={image} />

--- a/web-ui/src/pages/assignments/index.tsx
+++ b/web-ui/src/pages/assignments/index.tsx
@@ -190,7 +190,7 @@ export default function AssignmentsIndexPage() {
           <Col sm={24} md={8} className={styles.padding_left_right}>
             <Row>
               <Title level={2} className={styles.section_title}>
-                Where can I learn how to solve this assignment?
+                🧑‍🏫 Where can I learn how to solve this assignment?
               </Title>
               <Paragraph>
                 kthGPT is trying to find which lectures and where you can learn

--- a/web-ui/src/types/search.ts
+++ b/web-ui/src/types/search.ts
@@ -15,7 +15,14 @@ export interface Image {
   parse_image_content_ok: null | boolean;
 }
 
+export interface Hit {
+  id: string;
+  answer: string;
+  relevance: string;
+  lecture: Lecture;
+}
+
 export interface Question {
   id: string;
-  hits: Lecture[];
+  hits: Hit[];
 }

--- a/web-ui/src/types/search.ts
+++ b/web-ui/src/types/search.ts
@@ -8,6 +8,7 @@ export interface Image {
   can_ask_question: boolean;
   description_en: null | string;
   description_sv: null | string;
+  parse_image_upload_complete: boolean;
   create_search_queries_sv_ok: null | boolean;
   create_search_queries_en_ok: null | boolean;
   create_description_en_ok: null | boolean;


### PR DESCRIPTION
The purpose of this PR is:
- Improve the performance of image search and reduce number of gpt requests used for assignments

This PR will:
- Add an `ImageQuestionHit` model that's used to cache the answer and relevance gpt-requests
- Tweak the search by image UI slightly