### PR TITLE
Fix production web-ui builds not building

### DIFF
--- a/web-ui/.umirc.ts
+++ b/web-ui/.umirc.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'umi';
 
 export default defineConfig({
+  esbuildMinifyIIFE: true,
   routes: [
     { path: '/', component: 'index' },
 


### PR DESCRIPTION
This PR will:
- Fix production builds not building by setting `esbuildMinifyIIFE` to `true`