### PR TITLE
bump yt-dlp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,5 +68,5 @@ uvicorn==0.20.0
 validators==0.20.0
 yarl==1.8.2
 pytz==2022.7.1
-yt-dlp==2023.2.17
+yt-dlp==2023.7.6
 beautifulsoup4==4.11.2


### PR DESCRIPTION
The purpose of this PR is:
- fix issue where youtube downloads isn't working

This PR will:
- bump the yt-dlp version