### PR TITLE
Bump python version to 3.11

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
         cache: 'pip'
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Dependencies
       run: |
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Dependencies
       run: |

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/playwright
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 
 # set work directory
 WORKDIR /app

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Ask GPT-3 questions about KTH lectures',
     author='Ludwig Kristoffersson',
     author_email='ludwig@kristoffersson.org',
-    python_requires='>=3.10',
+    python_requires='>=3.11',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/playwright
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 
 # set work directory
 WORKDIR /app

--- a/worker/Dockerfile.gpu_accelerated
+++ b/worker/Dockerfile.gpu_accelerated
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/playwright
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 
 # set work directory
 WORKDIR /app


### PR DESCRIPTION
The purpose of this PR is:
- Solving build issues with dependencies relating to an older python version

This PR will:
- Bump python version used in docker images and workflows