### PR TITLE
Fix issue where youtube lectures sometimes fail

### DIFF
--- a/jobs/tasks/lecture/classify_video.py
+++ b/jobs/tasks/lecture/classify_video.py
@@ -103,6 +103,7 @@ def job(lecture_id: str, language: str):
 
     logger.info(f'response from openAI: {response}')
 
+    lecture.refresh()
     lecture.approved = category_is_ok
     lecture.save()
 

--- a/jobs/tasks/lecture/create_description.py
+++ b/jobs/tasks/lecture/create_description.py
@@ -37,6 +37,7 @@ def job(lecture_id: str, language: str):
         analysis_id=analysis.id,
     )
 
+    lecture.refresh()
     lecture.description = response
     lecture.save()
 

--- a/jobs/tasks/lecture/fetch_metadata.py
+++ b/jobs/tasks/lecture/fetch_metadata.py
@@ -37,6 +37,7 @@ def job(lecture_id: str, language: str):
     else:
         raise ValueError(f'unknown source {lecture.source}')
 
+    lecture.refresh()
     lecture.title = title
     lecture.date = date
     lecture.group = group


### PR DESCRIPTION
The purpose of this PR is:
- fixing an issue where youtube videos sometime fails to download

This PR will:
- refresh the lecture model before saving metadata, fixing an issue where the mp4 filepath is overriden by a metadata job running concurrently with a video download job